### PR TITLE
nix: add proper nix support

### DIFF
--- a/.github/workflows/flake.yml
+++ b/.github/workflows/flake.yml
@@ -1,0 +1,18 @@
+name: "Nix"
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v18
+      with:
+        extra_nix_config: |
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+    - name: Nix Build
+      run: |
+        nix build

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,76 @@
+# Haskell
+dist
+dist-*
+cabal-dev
+*.o
+*.hi
+*.hie
+*.chi
+*.chs.h
+*.dyn_o
+*.dyn_hi
+.hpc
+.hsenv
+.cabal-sandbox/
+cabal.sandbox.config
+*.prof
+*.aux
+*.hp
+*.eventlog
 .stack-work/
+cabal.project.local
+cabal.project.local~
+.HTF/
+.ghc.environment.*
+
+# Emacs
 *~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+# network security
+/network-security.data
+
+# Nix
+result

--- a/README.org
+++ b/README.org
@@ -3,5 +3,14 @@
 * Grammar
   [[file:docs/grammar.org][Document with Silverware+'s grammar]]
   
+* Development
 
+** Nix
 
+#+BEGIN_SRC shell
+  nix build
+#+END_SRC
+
+#+BEGIN_SRC shell
+  nix develop
+#+END_SRC

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1670597555,
+        "narHash": "sha256-/k939P2S2246G6K5fyvC0U2IWvULhb4ZJg9K7ZxsX+k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2dea0f4c2d6e4603f54b2c56c22367e77869490c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  description = "A very basic flake";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    flake-utils = {
+      url = "github:numtide/flake-utils";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { flake-utils, nixpkgs, self, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        config = {};
+        overlays = [];
+        pkgs = import nixpkgs { inherit config overlays system; };
+        haskellPackages = pkgs.haskellPackages;
+        packageName = "spatula";
+      in rec {
+        packages.${packageName} = # (ref:haskell-package-def)
+          pkgs.haskell.lib.dontCheck (
+            haskellPackages.callCabal2nix packageName self rec {
+              # Dependency overrides go here
+            }
+          );
+
+        defaultPackage = self.packages.${system}.${packageName};
+
+        devShell = haskellPackages.shellFor {
+          inputsFrom = builtins.attrValues self.packages.${system};
+          withHoogle = true;
+
+          packages = p: [
+          ];
+
+          buildInputs = with haskellPackages; [
+            cabal-install
+            stack
+
+            # Extra dev tools
+            ghcid
+            haskell-language-server
+            hlint
+            ormolu
+          ];
+        };
+      }
+    );
+}


### PR DESCRIPTION
This PR adds a `flake.nix` file into this project, it also includes a dev env with LSP embed into it.

However, I didn't have the time to check the codebase yet, it seems the build it's failing because of a type mistmatch.

```shell
❯ nix build                                  
warning: input 'flake-utils' has an override for a non-existent input 'nixpkgs'
error: builder for '/nix/store/12zxa5i1gkg6zdkzcig1khbvm8d18p2d-spatula-0.1.0.0.drv' failed with exit code 1;
       last 10 log lines:
       >                          (TForall
       >                             (AbstractionInfo
       >                                "typeB"
       >                                (TArrow
       >                                   (TArrow (TVariable "typeA") (TVariable "typeB"))
       >                                   (TArrow (TVariable "typeA") (TVariable "typeB"))))))
       >             typeCheck abst `shouldBe` Right type'’
       >    |
       > 41 |         typeCheck abst `shouldBe` Right type'
       >    |                                   ^^^^^^^^^^^
       For full logs, run 'nix log /nix/store/12zxa5i1gkg6zdkzcig1khbvm8d18p2d-spatula-0.1.0.0.drv'.
```

as of now I can't compile this with a pure nix build.

if you want to test just the devenv, I've only put cabal build tools and other goodies, no stack bs. Make sure to comment the following lines:

```nix

      in rec {
        #packages.${packageName} = # (ref:haskell-package-def)
        #  haskellPackages.callCabal2nix packageName self rec {
        #    # Dependency overrides go here
        #  };

        #defaultPackage = self.packages.${system}.${packageName};

        devShell = haskellPackages.shellFor {
          #inputsFrom = builtins.attrValues self.packages.${system};
          withHoogle = true;
```
then run
```shell
nix develop
```

@MMagueta @EduardoLR10 Please let me know what is wrong with the build.
